### PR TITLE
fix #7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM ruby:2.7.1-alpine
+
+RUN gem install bundler:2.1.4 --verbose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,19 @@
-FROM ruby:2.7.1-alpine
+FROM ruby:3.2.1
 
-RUN gem install bundler:2.1.4 --verbose
+ARG RAILS_ROOT=/codewars-exporter
+
+RUN apt-get install -y wget
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \ 
+    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
+RUN apt-get update && apt-get -y install google-chrome-stable
+
+RUN gem install bundler:2.4.19
+
+RUN mkdir $RAILS_ROOT
+WORKDIR $RAILS_ROOT
+
+COPY Gemfile Gemfile.lock  ./
+RUN bundle install --jobs 5
+
+ADD . $RAILS_ROOT
+ENV PATH=$RAILS_ROOT/bin:${PATH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,17 @@ FROM ruby:3.2.1
 
 ARG RAILS_ROOT=/codewars-exporter
 
-RUN apt-get install -y wget
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \ 
-    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
-RUN apt-get update && apt-get -y install google-chrome-stable
-
-RUN gem install bundler:2.4.19
+RUN apt-get update 
+RUN apt install -y firefox-esr
 
 RUN mkdir $RAILS_ROOT
 WORKDIR $RAILS_ROOT
 
 COPY Gemfile Gemfile.lock  ./
-RUN bundle install --jobs 5
+
+RUN bundle install
 
 ADD . $RAILS_ROOT
 ENV PATH=$RAILS_ROOT/bin:${PATH}
+
+

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,8 @@ gem 'nokogiri', '~> 1.15', '>= 1.15.4'
 gem 'pry-byebug'
 gem 'selenium-webdriver', '~> 4.4'
 gem 'terminal-table', '~> 1.8'
-gem 'watir', '~> 6.16', '>= 6.16.5'
+gem "watir", "~> 7.2"
+# gem 'watir', '~> 6.16', '>= 6.16.5'
 gem 'webdrivers', '~> 5.3', '>= 5.3.1'
 
 gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,9 +43,9 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.8.0)
-    watir (6.19.1)
+    watir (7.3.0)
       regexp_parser (>= 1.2, < 3)
-      selenium-webdriver (>= 3.142.7)
+      selenium-webdriver (~> 4.2)
     webdrivers (5.3.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -61,7 +61,7 @@ DEPENDENCIES
   rubocop
   selenium-webdriver (~> 4.4)
   terminal-table (~> 1.8)
-  watir (~> 6.16, >= 6.16.5)
+  watir (~> 7.2)
   webdrivers (~> 5.3, >= 5.3.1)
 
 BUNDLED WITH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,0 @@
-version: '3.7'
-
-services:
-  web:
-  db:
-
-volumes:
-  bundle_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.7'
+
+services:
+  web:
+  db:
+
+volumes:
+  bundle_cache:

--- a/lib/codewars_exporter/parser/nickname_parser.rb
+++ b/lib/codewars_exporter/parser/nickname_parser.rb
@@ -11,7 +11,7 @@ class NicknameParser
   attr_reader :email, :password, :username
 
   def initialize(email, password)
-    @browser = Watir::Browser.new
+    @browser = Watir::Browser.new :firefox, headless: true
     @email = email
     @password = password
   end


### PR DESCRIPTION
Я обновил версию ватира, потому что он выдает ошибку с селениумом
https://stackoverflow.com/questions/74997370/watir-browser-initialization-failing-due-to-selenium-argument-error

Собрал докерфайл на Firefox'e, он и ставится проще и отдельного вебдрайвера под селениум не требует.